### PR TITLE
Fix the repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mtanzi/automerger-action.git"
+    "url": "git+https://github.com/richard-scott/automerger-action.git"
   },
   "keywords": [
     "actions",


### PR DESCRIPTION
### The repository url specified in `package.json` is invalid. As a result, the use of a GitHub Action ends with an error:

```py
Error: Unable to resolve action richard-scott/action-automerger, repository not found
```